### PR TITLE
Update route-builder to 1.0.0

### DIFF
--- a/hello-world/app/utils/RouteUtils.js
+++ b/hello-world/app/utils/RouteUtils.js
@@ -7,7 +7,7 @@ var RouteConstants = require('../constants/RouteConstants');
 var Pages = AppConstants.Pages;
 var RouteConfig = RouteConstants.RouteConfig;
 
-var router = RouteBuilder(RouteConstants.ROUTES);
+var router = new RouteBuilder(RouteConstants.ROUTES);
 
 var RouteUtils = {
 

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -10,7 +10,7 @@
     "express": "4.10.1",
     "htmlescape": "1.0.0",
     "morgan": "1.4.1",
-    "route-builder": "0.0.1",
+    "route-builder": "1.0.0",
     "underscore": "1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I manually followed along with the repo instead of cloning. Since `npm router-builder` now causes version 1.0.0 to be installed, there's no reason to stay at 0.0.1. 

This pull request bumps the version number and adheres to a change made with the release of the 1.0.0 version.